### PR TITLE
Build with python3

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -30,6 +30,11 @@ def pyoutput(cmd):
     out = proc.communicate()[0]
     return out.rstrip()
 
+def pyconfigvar(name):
+    cmd = ('from distutils.sysconfig import get_config_var\n'
+           'print(get_config_var(%r))\n') % name
+    return pyoutput(cmd)
+
 # copy system environment variables related to compilation
 DefaultEnvironment(ENV=subdictionary(os.environ, '''
     PATH PYTHONPATH
@@ -73,7 +78,7 @@ btags = [env['build'], platform.machine()]
 if env['profile']:  btags.append('profile')
 builddir = env.Dir('build/' + '-'.join(btags))
 
-Export('env', 'pyoutput')
+Export('env', 'pyoutput', 'pyconfigvar')
 
 def GlobSources(pattern):
     """Same as Glob but also require that source node is a valid file.

--- a/SConstruct
+++ b/SConstruct
@@ -46,6 +46,9 @@ vars.Add('tests',
 vars.Add(EnumVariable('build',
     'compiler settings', 'fast',
     allowed_values=('debug', 'fast')))
+vars.Add(EnumVariable('tool',
+    'C++ compiler toolkit to be used', 'default',
+    allowed_values=('default', 'intelc')))
 vars.Add(BoolVariable('profile',
     'build with profiling information', False))
 vars.Add(PathVariable('prefix',

--- a/SConstruct
+++ b/SConstruct
@@ -16,20 +16,19 @@ Variables can be also assigned in a user-written script sconsvars.py.
 SCons construction environment can be customized in sconscript.local script.
 """
 
-# Top level targets that are defined in subsidiary SConscripts
-#
-
 import os
 import platform
 
+def subdictionary(d, keyset):
+    return dict(kv for kv in d.items() if kv[0] in keyset)
+
 # copy system environment variables related to compilation
-DefaultEnvironment(ENV={
-        'PATH' : os.environ['PATH'],
-        'PYTHONPATH' : os.environ.get('PYTHONPATH', ''),
-        'CPATH' : os.environ.get('CPATH', ''),
-        'LIBRARY_PATH' : os.environ.get('LIBRARY_PATH', ''),
-        'LD_LIBRARY_PATH' : os.environ.get('LD_LIBRARY_PATH', ''),
-    }
+DefaultEnvironment(ENV=subdictionary(os.environ, '''
+    PATH PYTHONPATH
+    CPATH CPLUS_INCLUDE_PATH LIBRARY_PATH LD_RUN_PATH
+    LD_LIBRARY_PATH DYLD_LIBRARY_PATH DYLD_FALLBACK_LIBRARY_PATH
+    MACOSX_DEPLOYMENT_TARGET LANG
+    '''.split())
 )
 
 # Create construction environment

--- a/SConstruct
+++ b/SConstruct
@@ -60,6 +60,14 @@ builddir = env.Dir('build/%s-%s' % (env['build'], platform.machine()))
 
 Export('env')
 
+def GlobSources(pattern):
+    """Same as Glob but also require that source node is a valid file.
+    """
+    rv = [f for f in Glob(pattern) if f.srcnode().isfile()]
+    return rv
+
+Export('GlobSources')
+
 if os.path.isfile('sconscript.local'):
     env.SConscript('sconscript.local')
 

--- a/SConstruct
+++ b/SConstruct
@@ -50,6 +50,8 @@ vars.Add(EnumVariable('tool',
     allowed_values=('default', 'intelc')))
 vars.Add(BoolVariable('profile',
     'build with profiling information', False))
+vars.Add('python',
+    'Python executable to use for installation.', 'python3')
 vars.Add(PathVariable('prefix',
     'installation prefix directory', '/usr/local'))
 vars.Update(env)

--- a/SConstruct
+++ b/SConstruct
@@ -17,10 +17,18 @@ SCons construction environment can be customized in sconscript.local script.
 """
 
 import os
+import subprocess
 import platform
 
 def subdictionary(d, keyset):
     return dict(kv for kv in d.items() if kv[0] in keyset)
+
+def pyoutput(cmd):
+    proc = subprocess.Popen([env['python'], '-c', cmd],
+                            stdout=subprocess.PIPE,
+                            universal_newlines=True)
+    out = proc.communicate()[0]
+    return out.rstrip()
 
 # copy system environment variables related to compilation
 DefaultEnvironment(ENV=subdictionary(os.environ, '''
@@ -65,7 +73,7 @@ btags = [env['build'], platform.machine()]
 if env['profile']:  btags.append('profile')
 builddir = env.Dir('build/' + '-'.join(btags))
 
-Export('env')
+Export('env', 'pyoutput')
 
 def GlobSources(pattern):
     """Same as Glob but also require that source node is a valid file.

--- a/SConstruct
+++ b/SConstruct
@@ -57,7 +57,9 @@ vars.Add(PathVariable('bindir',
 vars.Update(env)
 env.Help(MY_SCONS_HELP % vars.GenerateHelpText(env))
 
-builddir = env.Dir('build/%s-%s' % (env['build'], platform.machine()))
+btags = [env['build'], platform.machine()]
+if env['profile']:  btags.append('profile')
+builddir = env.Dir('build/' + '-'.join(btags))
 
 Export('env')
 

--- a/SConstruct
+++ b/SConstruct
@@ -41,7 +41,8 @@ env.EnsureSConsVersion(0, 98, 1)
 # Customizable compile variables
 vars = Variables('sconsvars.py')
 
-vars.Add('tests', 'Custom list of unit test sources', None)
+vars.Add('tests',
+    'Fixed-string patterns for selecting unit test sources.', None)
 vars.Add(EnumVariable('build',
     'compiler settings', 'fast',
     allowed_values=('debug', 'fast')))

--- a/site_scons/mpbcligabuildutils.py
+++ b/site_scons/mpbcligabuildutils.py
@@ -4,26 +4,30 @@
 '''
 
 import os
+import re
 
 MYDIR = os.path.dirname(os.path.abspath(__file__))
 
 def gitinfo():
     'Extract dictionary of version data from git records.'
-    import re
     from subprocess import Popen, PIPE
     global _cached_gitinfo
-    if _cached_gitinfo is not None:  return _cached_gitinfo
-    rv = _cached_gitinfo = {}
+    if _cached_gitinfo is not None:
+        return _cached_gitinfo
     nullfile = open(os.devnull, 'w')
-    kw = dict(stdout=PIPE, stderr=nullfile, cwd=MYDIR)
+    kw = dict(stdout=PIPE, stderr=nullfile, cwd=MYDIR,
+              universal_newlines=True)
     proc = Popen(['git', 'describe', '--match=v[[:digit:]]*'], **kw)
     desc = proc.stdout.read()
-    if proc.wait():  return gitinfo()
-    proc = Popen(['git', 'log', '-1', '--format=%H%n%ai%n%at%n%an'], **kw)
+    if proc.wait():
+        _cached_gitinfo = {}
+        return gitinfo()
+    proc = Popen(['git', 'log', '-1', '--format=%H%n%ci%n%ct%n%an'], **kw)
     glog = proc.stdout.read()
     words = desc.strip().split('-')
     vtag = words[0].lstrip('v')
     vnum = int((words[1:2] or ['0'])[0])
+    rv = {}
     rv['commit'], rv['date'], rv['timestamp'], rv['author'] = [
             s.strip() for s in glog.strip().split('\n')]
     rv['timestamp'] = int(rv['timestamp'])

--- a/site_scons/site_tools/cxxtest.py
+++ b/site_scons/site_tools/cxxtest.py
@@ -69,7 +69,9 @@ from SCons.Util import PrependPath, unique, uniquer
 import os
 
 # A warning class to notify users of problems
-class ToolCxxTestWarning(SCons.Warnings.Warning):
+class ToolCxxTestWarning(SCons.Warnings.SConsWarning
+                         if hasattr(SCons.Warnings, 'SConsWarning')
+                         else SCons.Warnings.Warning):
     pass
 
 SCons.Warnings.enableWarningClass(ToolCxxTestWarning)

--- a/site_scons/site_tools/cxxtest.py
+++ b/site_scons/site_tools/cxxtest.py
@@ -15,7 +15,7 @@
 # Maintainer: Gašper Ažman <gasper.azman@gmail.com>
 #
 # This file is maintained as a part of the CxxTest test suite.
-# 
+#
 # == About ==
 #
 # This builder correctly tracks dependencies and supports just about every
@@ -92,7 +92,7 @@ def multiget(dictlist, key, default = None):
     dictionaries, the default is returned.
     """
     for dict in dictlist:
-        if dict.has_key(key):
+        if key in dict:
             return dict[key]
     else:
         return default
@@ -155,14 +155,14 @@ def UnitTest(env, target, source = [], **kwargs):
 
 def isValidScriptPath(cxxtestgen):
     """check keyword arg or environment variable locating cxxtestgen script"""
-       
+
     if cxxtestgen and os.path.exists(cxxtestgen):
         return True
     else:
         SCons.Warnings.warn(ToolCxxTestWarning,
                             "Invalid CXXTEST environment variable specified!")
         return False
-    
+
 def defaultCxxTestGenLocation(env):
     return os.path.join(
                 envget(env, 'CXXTEST_CXXTESTGEN_DEFAULT_LOCATION'),
@@ -171,7 +171,7 @@ def defaultCxxTestGenLocation(env):
 
 def findCxxTestGen(env):
     """locate the cxxtestgen script by checking environment, path and project"""
-    
+
     # check the SCons environment...
     # Then, check the OS environment...
     cxxtest = envget(env, 'CXXTEST', None)
@@ -201,7 +201,7 @@ def findCxxTestGen(env):
         # make sure it was correct
         if isValidScriptPath(cxxtest):
            return os.path.realpath(cxxtest)
-    
+
     # No valid environment variable found, so...
     # Next, check the path...
     # Next, check the project
@@ -209,10 +209,10 @@ def findCxxTestGen(env):
             envget(env, 'CXXTEST_INSTALL_DIR'),
             envget(env, 'CXXTEST_CXXTESTGEN_DEFAULT_LOCATION'))
 
-    cxxtest = (env.WhereIs(envget(env, 'CXXTEST_CXXTESTGEN_SCRIPT_NAME')) or 
+    cxxtest = (env.WhereIs(envget(env, 'CXXTEST_CXXTESTGEN_SCRIPT_NAME')) or
                env.WhereIs(envget(env, 'CXXTEST_CXXTESTGEN_SCRIPT_NAME'),
                    path=[Dir(check_path).abspath]))
-    
+
     if cxxtest:
         return cxxtest
     else:
@@ -280,13 +280,10 @@ def generate(env, **kwargs):
                             python, docs and other subdirectories.
     ... and all others that Program() accepts, like CPPPATH etc.
     """
-
-    print "Loading CxxTest tool..."
-
     #
     # Expected behaviour: keyword arguments override environment variables;
     # environment variables override default settings.
-    #          
+    #
     env.SetDefault( CXXTEST_RUNNER  = 'ErrorPrinter'        )
     env.SetDefault( CXXTEST_OPTS    = ''                    )
     env.SetDefault( CXXTEST_SUFFIX  = '.t.h'                )
@@ -307,16 +304,16 @@ def generate(env, **kwargs):
     env.SetDefault( CXXTEST_CXXTESTGEN_SCRIPT_NAME = 'cxxtestgen' )
 
     #Here's where keyword arguments are applied
-    apply(env.Replace, (), kwargs)
+    env.Replace(**kwargs)
 
     #If the user specified the path to CXXTEST, make sure it is correct
     #otherwise, search for and set the default toolpath.
-    if (not kwargs.has_key('CXXTEST') or not isValidScriptPath(kwargs['CXXTEST']) ):
+    if 'CXXTEST' not in kwargs or not isValidScriptPath(kwargs['CXXTEST']):
         env["CXXTEST"] = findCxxTestGen(env)
 
     # find and add the CxxTest headers to the path.
     env.AppendUnique( CXXTEST_CPPPATH = findCxxTestHeaders(env) )
-    
+
     cxxtest = env['CXXTEST']
     if cxxtest:
         #
@@ -397,4 +394,3 @@ def generate(env, **kwargs):
 
 def exists(env):
     return os.path.exists(env['CXXTEST'])
-

--- a/src/AtomFilter_t.hpp
+++ b/src/AtomFilter_t.hpp
@@ -9,6 +9,8 @@
 #ifndef ATOMFILTER_T_HPP_INCLUDED
 #define ATOMFILTER_T_HPP_INCLUDED
 
+#include <cstddef>
+
 class Atom_t;
 class Molecule;
 

--- a/src/EmbedPython.cpp
+++ b/src/EmbedPython.cpp
@@ -16,8 +16,8 @@ void initializePython()
         return;
     }
     static int py_argc = 1;
-    static char arg0[7] = "python";
-    static char* py_argv[] = {arg0};
+    static wchar_t arg0[7] = L"python";
+    static wchar_t* py_argv[] = {arg0};
     Py_Initialize();
     PySys_SetArgv(py_argc, py_argv);
     // Make sure Python does not eat SIGINT.

--- a/src/Molecule.cpp
+++ b/src/Molecule.cpp
@@ -1825,7 +1825,7 @@ void Molecule::WriteStream(ostream& fid, string title) const
 boost::python::object Molecule::newDiffPyStructure() const
 {
     namespace python = boost::python;
-    python::object mstru = python::import("diffpy.Structure");
+    python::object mstru = python::import("diffpy.structure");
     python::object stru = mstru.attr("Structure")();
     return stru;
 }

--- a/src/SConscript.configure
+++ b/src/SConscript.configure
@@ -1,8 +1,9 @@
-Import('env')
+Import('env', 'pyoutput')
+
+pyversion = pyoutput('import sys; print("%i.%i" % sys.version_info[:2])')
 
 # Helper functions -----------------------------------------------------------
 
-boostlibtags = ['-mt', '']
 def configure_boost_library(libname):
     '''Add a boost library to the configured environment allowing for any
     of the boostlibtags name extensions.
@@ -11,11 +12,17 @@ def configure_boost_library(libname):
 
     Note: CheckLib function automatically adds library to the environment.
     '''
+    mttags = ['', '-mt']
+    boostlibtags = mttags
+    # check more tags for boost_python
+    if libname == 'boost_python':
+        major, minor = pyversion.split('.')
+        pytags = [major + minor, major, '']
+        boostlibtags = [(pt + mt) for mt in mttags for pt in pytags]
     # using global conf defined below
     for t in boostlibtags:
         libnamefull = libname + t
         if conf.CheckLib(libnamefull, language='C++'):
-            boostlibtags[:] = [t]
             return
     # library not found here
     print('This program requires %r library' % libname)
@@ -25,11 +32,18 @@ def configure_boost_library(libname):
 
 conf = Configure(env)
 
+# python shared library
+pylibname = 'python' + pyversion
+if not conf.CheckLib(pylibname, language='C++'):
+    print('This program requires %r shared library' % pylibname)
+    Exit(1)
+
 # boost_python
 configure_boost_library('boost_python')
 configure_boost_library('boost_filesystem')
 configure_boost_library('boost_system')
 
 env = conf.Finish()
+Export('env')
 
 # vim: ft=python

--- a/src/SConscript.configure
+++ b/src/SConscript.configure
@@ -1,24 +1,5 @@
 Import('env')
 
-# Define Custom configure checks ---------------------------------------------
-
-def CheckBoostVersion(context, version):
-    '''Check if Boost Library is at least of specified version
-    '''
-    # Boost versions are in format major.minor.subminor
-    v_arr = map(int, version.split("."))
-    version_n = sum([(v * n) for v, n in zip(v_arr, (1e5, 1e2, 1))])
-    context.Message('Checking for Boost version >= %s... ' % (version))
-    rv = context.TryCompile('\n'.join([
-        '#include <boost/version.hpp>',
-        '#if BOOST_VERSION < %d',
-        '#error Installed boost is too old!',
-        '#endif',
-        'int main() { return 0; }',
-        '', ]) % version_n, '.cpp')
-    context.Result(rv)
-    return rv
-
 # Helper functions -----------------------------------------------------------
 
 boostlibtags = ['-mt', '']
@@ -42,9 +23,7 @@ def configure_boost_library(libname):
 
 # Start configuration --------------------------------------------------------
 
-conf = Configure(env, custom_tests={
-    'CheckBoostVersion' : CheckBoostVersion,
-    })
+conf = Configure(env)
 
 # boost_python
 configure_boost_library('boost_python')

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -34,12 +34,12 @@ if not (GetOption('clean') or env.GetOption('help')):
 # Compiler specific options
 if icpc:
     # options for Intel C++ compiler on hpc dev-intel07
-    env.AppendUnique(CCFLAGS=['-w1', '-fp-model', 'precise'])
+    env.PrependUnique(CCFLAGS=['-w1', '-fp-model', 'precise'])
     env.PrependUnique(LIBS=['imf'])
     fast_optimflags = ['-fast']
 else:
     # g++ options
-    env.AppendUnique(CCFLAGS=['-Wall'])
+    env.PrependUnique(CCFLAGS=['-Wall'])
     fast_optimflags = ['-ffast-math']
 
 # Configure build variants

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -1,6 +1,6 @@
 import os
 
-Import('env')
+Import('env', 'GlobSources')
 
 # Build environment configuration --------------------------------------------
 
@@ -62,7 +62,7 @@ def isLibSource(f):
     return rv
 
 env['binaries'] = []
-env['lib_sources'] = [f for f in env.Glob('*.cpp') if isLibSource(f)]
+env['lib_sources'] = [f for f in GlobSources('*.cpp') if isLibSource(f)]
 # This SConscript updates Version.cpp and adds it to lib_sources
 SConscript('SConscript.version')
 env['lib_objects'] = [env.Object(f) for f in env['lib_sources']]

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -47,7 +47,7 @@ if env['build'] == 'debug':
     env.Append(CCFLAGS='-g')
 elif env['build'] == 'fast':
     env.AppendUnique(CCFLAGS=['-O3'] + fast_optimflags)
-    env.AppendUnique(CPPDEFINES='NDEBUG')
+    env.AppendUnique(CPPDEFINES={'NDEBUG' : None})
     env.AppendUnique(LINKFLAGS=fast_linkflags)
 
 if env['profile']:

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -1,6 +1,6 @@
 import os
 
-Import('env', 'GlobSources')
+Import('env', 'GlobSources', 'pyconfigvar')
 
 # Build environment configuration --------------------------------------------
 
@@ -53,6 +53,7 @@ if icpc:
 else:
     # g++ options
     env.PrependUnique(CCFLAGS=['-Wall'])
+    env.Append(LINKFLAGS='-Wl,-rpath,{!r}'.format(pyconfigvar('LIBDIR')))
     fast_optimflags = ['-ffast-math']
 
 # Configure build variants

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -16,6 +16,13 @@ if icpc:
 env.ParseConfig("python-config --includes")
 env.ParseConfig("python-config --ldflags")
 env.ParseConfig("gsl-config --cflags --libs")
+
+fast_linkflags = ['-s']
+
+# Platform specific intricacies.
+if env['PLATFORM'] == 'darwin':
+    fast_linkflags[:] = []
+
 # configure version specific options.
 if not (GetOption('clean') or env.GetOption('help')):
     SConscript('SConscript.configure')
@@ -37,6 +44,7 @@ if env['build'] == 'debug':
 elif env['build'] == 'fast':
     env.AppendUnique(CCFLAGS=['-O3'] + fast_optimflags)
     env.AppendUnique(CPPDEFINES='NDEBUG')
+    env.AppendUnique(LINKFLAGS=fast_linkflags)
 
 if env['profile']:
     env.AppendUnique(CCFLAGS='-pg')

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -62,10 +62,10 @@ def isLibSource(f):
     return rv
 
 env['binaries'] = []
-env['lib_sources'] = filter(isLibSource, env.Glob('*.cpp'))
+env['lib_sources'] = [f for f in env.Glob('*.cpp') if isLibSource(f)]
 # This SConscript updates Version.cpp and adds it to lib_sources
 SConscript('SConscript.version')
-env['lib_objects'] = map(env.Object, env['lib_sources'])
+env['lib_objects'] = [env.Object(f) for f in env['lib_sources']]
 
 # Top Level Targets ----------------------------------------------------------
 
@@ -99,7 +99,7 @@ def get_target_path(f):
         fb += '-debug'
     tgt = os.path.join(env['bindir'], fb + fe)
     return tgt
-bin_targets = map(get_target_path, env['binaries'])
+bin_targets = [get_target_path(f) for f in env['binaries']]
 
 Alias('install-bin', InstallAs(bin_targets, env['binaries']))
 

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -56,6 +56,9 @@ else:
     env.Append(LINKFLAGS='-Wl,-rpath,{!r}'.format(pyconfigvar('LIBDIR')))
     fast_optimflags = ['-ffast-math']
 
+# required by libblitz-1.0.2 from conda-forge
+env.Append(CCFLAGS=['-pthread'])
+
 # Configure build variants
 if env['build'] == 'debug':
     env.Append(CCFLAGS='-g')

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -42,6 +42,7 @@ if env['PLATFORM'] == 'darwin':
 # configure version specific options.
 if not (GetOption('clean') or env.GetOption('help')):
     SConscript('SConscript.configure')
+    Import('env')
 
 # Compiler specific options
 if icpc:

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -27,6 +27,10 @@ env.ParseConfig("gsl-config --cflags --libs")
 
 fast_linkflags = ['-s']
 
+# Specify minimum C++ standard.  Allow later standard from sconscript.local.
+# In case of multiple `-std` options the last option holds.
+env.PrependUnique(CXXFLAGS='-std=c++98', delete_existing=1)
+
 # Platform specific intricacies.
 if env['PLATFORM'] == 'darwin':
     fast_linkflags[:] = []

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -11,9 +11,13 @@ env.PrependUnique(CPPPATH=Dir('.'))
 # ignore it in the system environment.
 env.PrependUnique(LIBPATH=env['ENV'].get('LIBRARY_PATH', '').split(':'))
 
-# Use Intel C++ compiler when it is available
-icpc = env.WhereIs('icpc')
-if icpc:
+# Use Intel C++ compiler if requested by the user.
+icpc = None
+if env['tool'] == 'intelc':
+    icpc = env.WhereIs('icpc')
+    if not icpc:
+        print("Cannot find the Intel C/C++ compiler 'icpc'.")
+        Exit(1)
     env.Tool('intelc', topdir=icpc[:icpc.rfind('/bin')])
 
 # Declare external libraries.

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -20,9 +20,13 @@ if env['tool'] == 'intelc':
         Exit(1)
     env.Tool('intelc', topdir=icpc[:icpc.rfind('/bin')])
 
+# use python3-config at the same path as python
+pybindir = os.path.dirname(env.WhereIs(env['python']))
+pythonconfig = os.path.join(pybindir, 'python3-config')
+
 # Declare external libraries.
-env.ParseConfig("python-config --includes")
-env.ParseConfig("python-config --ldflags")
+env.ParseConfig(pythonconfig + " --includes")
+env.ParseConfig(pythonconfig + " --ldflags")
 env.ParseConfig("gsl-config --cflags --libs")
 
 fast_linkflags = ['-s']

--- a/src/SConscript.main
+++ b/src/SConscript.main
@@ -7,6 +7,10 @@ Import('env')
 # The directory of this SConscript should be searched first for any headers.
 env.PrependUnique(CPPPATH=Dir('.'))
 
+# Insert LIBRARY_PATH explicitly because some compilers
+# ignore it in the system environment.
+env.PrependUnique(LIBPATH=env['ENV'].get('LIBRARY_PATH', '').split(':'))
+
 # Use Intel C++ compiler when it is available
 icpc = env.WhereIs('icpc')
 if icpc:

--- a/src/SConscript.tests
+++ b/src/SConscript.tests
@@ -9,14 +9,20 @@ env_test['CXXTEST_SUFFIX'] = '.hpp'
 
 # Targets --------------------------------------------------------------------
 
-# alltests -- the unit test driver
-test_sources = []
+def srcincluded(f):
+    fl = str(f).lower()
+    rv = True
+    if env_test.get('tests'):
+        tpatterns = Split(env_test['tests'].lower().replace(',', ' '))
+        rv = any(tp in fl for tp in tpatterns)
+    return rv
 
-# add all unit test modules when variable tests was not set.
-if env_test.get('tests') is None:
-    test_sources += GlobSources('Test*.hpp')
-else:
-    test_sources = env_test.Split(env_test['tests'])
+# alltests -- the unit test driver source files
+test_sources = [f for f in GlobSources('Test*.hpp') if srcincluded(f)]
+if not test_sources:
+    ts = env_test.get('tests', '')
+    print("Cannot find any test matching 'tests={}'.".format(ts))
+    Exit(1)
 
 # special builder for tests_dir.hpp
 def build_header(target, source, env):

--- a/src/SConscript.tests
+++ b/src/SConscript.tests
@@ -1,6 +1,6 @@
 import os
 
-Import('env')
+Import('env', 'GlobSources')
 
 # Environment for building unit test driver
 env_test = env.Clone()
@@ -14,7 +14,7 @@ test_sources = []
 
 # add all unit test modules when variable tests was not set.
 if env_test.get('tests') is None:
-    test_sources += env_test.Glob('Test*.hpp')
+    test_sources += GlobSources('Test*.hpp')
 else:
     test_sources = env_test.Split(env_test['tests'])
 

--- a/src/SConscript.tests
+++ b/src/SConscript.tests
@@ -22,8 +22,9 @@ else:
 def build_header(target, source, env):
     tdfullpath = source[0].abspath
     flds = {'tests_dir' : os.path.dirname(tdfullpath)}
-    tests_dir_code = open(tdfullpath).read() % flds
-    open(str(target[0]), 'w').write(tests_dir_code)
+    tests_dir_code = source[0].get_text_contents() % flds
+    with open(target[0].path, 'w') as fp:
+        fp.write(tests_dir_code)
     return None
 
 env_test.Append(BUILDERS={'BuildHeader_hpp' :

--- a/src/SConscript.version
+++ b/src/SConscript.version
@@ -19,11 +19,18 @@ env.Append(BUILDERS={'BuildVersionCode' :
 
 vcpp = File('Version.cpp')
 
+MY_GIT_MISSING_ERROR_MSG = """
+Cannot determine liga version.  Please compile from a git repository.
+"""
+
 # Construct Version.cpp only if it does not exist
 if not os.path.isfile(str(vcpp.srcnode())):
     from mpbcligabuildutils import gitinfo
     vtpl = File('Version.tpl')
     ginfo = gitinfo()
+    if not ginfo:
+        print(MY_GIT_MISSING_ERROR_MSG)
+        Exit(1)
     vcpp, = env.BuildVersionCode(['Version.cpp'], vtpl)
     env.Depends(vcpp, env.Value(ginfo['version'] + ginfo['commit']))
 

--- a/src/SConscript.version
+++ b/src/SConscript.version
@@ -5,10 +5,11 @@ Import('env')
 def build_VersionCode(target, source, env):
     import string
     from mpbcligabuildutils import gitinfo
-    tplcode = source[0].get_contents()
+    tplcode = source[0].get_text_contents()
     versiontemplate = string.Template(tplcode)
     versioncode = versiontemplate.safe_substitute(gitinfo())
-    open(target[0].path, 'w').write(versioncode)
+    with open(target[0].path, 'w') as fp:
+        fp.write(versioncode)
     return None
 
 env.Append(BUILDERS={'BuildVersionCode' :


### PR DESCRIPTION
Update scons build scripts for Python 3 and the latest version of scons.
Adjust Python embedding for Python 3 API and fix linkage with python and boost_python.
Add scons variable `python` for selecting Python 3 instance to embed and link with.
Improve handling of the `tests` scons variable for building partial unit tests.

This builds and passes tests on Mac OS X with recent Homebrew packages
and with system packages on Debian Linux.